### PR TITLE
fix: seq persistence and config improvements

### DIFF
--- a/clawman.go
+++ b/clawman.go
@@ -122,8 +122,8 @@ func (r *Clawman) pullAndDispatch(ctx context.Context, seq, limit int64) (int64,
 		}).Err(); err != nil {
 			return seq, fmt.Errorf("xadd %s failed: %w", stream, err)
 		}
-		if err := r.redis.IncrBy(ctx, r.cfg.WeComSeqKey, chatData.Seq-seq).Err(); err != nil {
-			return seq, fmt.Errorf("incr seq in redis: %w", err)
+		if err := r.redis.Set(ctx, r.cfg.WeComSeqKey, chatData.Seq, 0).Err(); err != nil {
+			return seq, fmt.Errorf("set seq in redis: %w", err)
 		}
 		seq = chatData.Seq
 	}
@@ -136,14 +136,6 @@ func streamValues(msg WeComMessage) map[string]any {
 		"msgid": msg.MsgID,
 		"raw":   msg.RawContent,
 	}
-}
-
-func mustJSON(v any) string {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return "[]"
-	}
-	return string(b)
 }
 
 func streamKey(prefix string, msg *WeComMessage) string {

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strconv"
 )
 
 const (
@@ -23,15 +24,22 @@ type Config struct {
 }
 
 func LoadConfig() (Config, error) {
+	redisDB := 0
+	if v := os.Getenv("REDIS_DB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			redisDB = n
+		}
+	}
 	cfg := Config{
 		RedisAddr:     envOrDefault("REDIS_ADDR", defaultRedisAddr),
 		RedisPassword: os.Getenv("REDIS_PASSWORD"),
+		RedisDB:       redisDB,
 		StreamPrefix:  envOrDefault("STREAM_PREFIX", defaultStreamPrefix),
 
-		WeComCorpID:      os.Getenv("WECOM_CORP_ID"),
-		WeComCorpSecret:  os.Getenv("WECOM_CORP_SECRET"),
-		WeComPrivateKey:  os.Getenv("WECOM_RSA_PRIVATE_KEY"),
-		WeComSeqKey:      envOrDefault("WECOM_SEQ_KEY", defaultWeComSeqKey),
+		WeComCorpID:     os.Getenv("WECOM_CORP_ID"),
+		WeComCorpSecret: os.Getenv("WECOM_CORP_SECRET"),
+		WeComPrivateKey: os.Getenv("WECOM_RSA_PRIVATE_KEY"),
+		WeComSeqKey:     envOrDefault("WECOM_SEQ_KEY", defaultWeComSeqKey),
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## 发现的问题

### 1. seq 持久化逻辑错误（clawman.go:125）
`IncrBy(chatData.Seq - seq)` 用增量更新 seq，但 seq 是绝对值不是增量，应该用 `Set` 直接覆盖。

**修复前：**
```go
r.redis.IncrBy(ctx, r.cfg.WeComSeqKey, chatData.Seq-seq)
```
**修复后：**
```go
r.redis.Set(ctx, r.cfg.WeComSeqKey, chatData.Seq, 0)
```

### 2. 未使用的 mustJSON 函数（clawman.go:141）
定义了但从未调用，删除。

### 3. RedisDB 未从环境变量读取（config.go）
`Config.RedisDB` 字段永远是 0，补充 `REDIS_DB` 环境变量读取。