### PR TITLE
feat: TypeScript agent consumer with Claude SDK

### DIFF
--- a/agent/index.ts
+++ b/agent/index.ts
@@ -1,0 +1,57 @@
+import Redis from "ioredis";
+import { query } from "@anthropic-ai/claude-code";
+
+const STREAM = process.env.STREAM_KEY ?? "stream:group:default";
+const GROUP = "tinyclaw";
+const CONSUMER = `agent-${process.pid}`;
+const BLOCK_MS = 5000;
+
+const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379");
+
+async function ensureGroup() {
+  try {
+    await redis.xgroup("CREATE", STREAM, GROUP, "0", "MKSTREAM");
+  } catch (e: any) {
+    if (!e.message?.includes("BUSYGROUP")) throw e;
+  }
+}
+
+async function process(id: string, raw: string) {
+  let output = "";
+  for await (const chunk of query({ prompt: raw, options: { maxTurns: 10 } })) {
+    if (chunk.type === "result") {
+      output = chunk.result ?? "";
+    }
+  }
+  console.log(`processed id=${id} output_len=${output.length}`);
+}
+
+async function run() {
+  await ensureGroup();
+  console.log(`agent started stream=${STREAM} group=${GROUP} consumer=${CONSUMER}`);
+
+  while (true) {
+    const results = await redis.xreadgroup(
+      "GROUP", GROUP, CONSUMER,
+      "COUNT", "1",
+      "BLOCK", String(BLOCK_MS),
+      "STREAMS", STREAM, ">"
+    );
+
+    if (!results) continue;
+
+    for (const [, messages] of results as any[]) {
+      for (const [id, fields] of messages) {
+        const raw = fields[fields.indexOf("raw") + 1] ?? "";
+        try {
+          await process(id, raw);
+          await redis.xack(STREAM, GROUP, id);
+        } catch (e) {
+          console.error(`error id=${id}`, e);
+        }
+      }
+    }
+  }
+}
+
+run().catch(console.error);

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tinyclaw-agent",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node --experimental-strip-types index.ts",
+    "test": "node --experimental-strip-types --test index.test.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-code": "latest",
+    "ioredis": "^5.3.2"
+  }
+}


### PR DESCRIPTION
## 变更内容

新增 `agent/` 目录：TypeScript 版 agent 消费循环。

### 设计
- 独立容器，与 Go ingress 完全解耦
- `XREADGROUP BLOCK` 持续监听 stream，不轮询
- 使用 `@anthropic-ai/claude-code` SDK，agent 完全自主
- 处理成功后才 `XACK`，at-least-once 语义

### 文件
- `agent/index.ts`: 消费循环主逻辑
- `agent/package.json`: 依赖声明

### 环境变量
- `STREAM_KEY`: 监听的 stream（默认 `stream:group:default`）
- `REDIS_URL`: Redis 连接地址（默认 `redis://localhost:6379`）
- `ANTHROPIC_API_KEY`: Claude API key