### PR TITLE
fix(ingress): enrich stream fields with text, from, msgtime, msgtype

### DIFF
--- a/clawman.go
+++ b/clawman.go
@@ -181,9 +181,34 @@ func (r *Clawman) pullAndDispatch(ctx context.Context, seq, limit int64) (int64,
 
 func streamValues(msg WeComMessage) map[string]any {
 	return map[string]any{
-		"msgid": msg.MsgID,
-		"raw":   msg.RawContent,
+		"msgid":   msg.MsgID,
+		"from":    msg.From,
+		"msgtime": msg.MsgTime,
+		"msgtype": msg.MsgType,
+		"text":    extractText(msg.RawContent, msg.MsgType),
+		"raw":     msg.RawContent,
 	}
+}
+
+// extractText pulls the human-readable text out of the raw WeCom message JSON.
+// Falls back to the raw content string so the agent always has something to work with.
+func extractText(raw, msgType string) string {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return raw
+	}
+	switch msgType {
+	case "text":
+		var t struct {
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(m["text"], &t); err == nil && t.Content != "" {
+			return t.Content
+		}
+	case "image", "voice", "video", "file":
+		return "[" + msgType + "]"
+	}
+	return raw
 }
 
 // cacheTarget resolves and caches the display name for a room/user so egress


### PR DESCRIPTION
## 问题

`streamValues` 只写了 `msgid` 和 `raw`。agent 的 `selectText()` 找不到 `text` 字段时会 fallback 到 `JSON.stringify(fields)`，导致 agent 收到的是 `{"msgid":"...","raw":"..."}` 这样的 JSON 字符串，而不是实际消息内容。

## 修复

新增结构化字段：
- `text`：提取的可读文本（text 消息取 content，媒体消息返回 `[type]` 占位符，其他 fallback 到 raw）
- `from`：发送方 user ID
- `msgtime`：unix 时间戳
- `msgtype`：消息类型

## 变更文件

- `clawman.go`：`streamValues` + 新增 `extractText` 辅助函数