### PR TITLE
fix: harden admin control pages

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -232,6 +232,9 @@ func (s *Server) handleAdminAgents(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, http.StatusBadRequest, "list_failed", err.Error())
 			return
 		}
+		if agents == nil {
+			agents = []core.Agent{}
+		}
 		writeAPIJSON(w, http.StatusOK, adminAgentsResponse{Agents: agents})
 	case http.MethodPost:
 		var input core.UpsertAgentInput
@@ -426,29 +429,53 @@ func (s *Server) handleDeliveryAction(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAdminRooms(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "use GET")
-		return
-	}
-	store, ok := s.core.(AdminStore)
-	if !ok {
-		writeAPIError(w, http.StatusServiceUnavailable, "disabled", "admin API is unavailable")
-		return
-	}
 	if !s.authenticateAdmin(r) {
 		writeAPIError(w, http.StatusUnauthorized, "unauthorized", "missing or invalid admin credentials")
 		return
 	}
-	rooms, err := store.ListAdminRooms(r.Context(), parsePositiveInt(r.URL.Query().Get("limit"), 100))
-	if err != nil {
-		writeAPIError(w, http.StatusBadRequest, "list_failed", err.Error())
+	switch r.Method {
+	case http.MethodGet:
+		store, ok := s.core.(AdminStore)
+		if !ok {
+			writeAPIError(w, http.StatusServiceUnavailable, "disabled", "admin API is unavailable")
+			return
+		}
+		rooms, err := store.ListAdminRooms(r.Context(), parsePositiveInt(r.URL.Query().Get("limit"), 100))
+		if err != nil {
+			writeAPIError(w, http.StatusBadRequest, "list_failed", err.Error())
+			return
+		}
+		response := make([]adminRoomSummaryResponse, 0, len(rooms))
+		for _, room := range rooms {
+			response = append(response, adminRoomSummaryToResponse(room))
+		}
+		writeAPIJSON(w, http.StatusOK, adminRoomsResponse{Rooms: response})
+	case http.MethodPost:
+		s.handleAdminRegisterRoom(w, r)
+	default:
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "use GET or POST")
+	}
+}
+
+func (s *Server) handleAdminRegisterRoom(w http.ResponseWriter, r *http.Request) {
+	if s.core == nil {
+		writeAPIError(w, http.StatusServiceUnavailable, "disabled", "core API is unavailable")
 		return
 	}
-	response := make([]adminRoomSummaryResponse, 0, len(rooms))
-	for _, room := range rooms {
-		response = append(response, adminRoomSummaryToResponse(room))
+	var input core.RegisterRoomInput
+	if err := readJSONBody(r, &input); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
 	}
-	writeAPIJSON(w, http.StatusOK, adminRoomsResponse{Rooms: response})
+	result, err := s.core.RegisterRoom(r.Context(), input)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	writeAPIJSON(w, http.StatusOK, registerRoomResponse{
+		Room:         roomToResponse(result.Room),
+		AgentSession: agentSessionToResponse(result.AgentSession),
+	})
 }
 
 func (s *Server) handleAdminRoomAction(w http.ResponseWriter, r *http.Request) {
@@ -519,6 +546,9 @@ func (s *Server) handleAdminRoomMemory(w http.ResponseWriter, r *http.Request, r
 	if err != nil {
 		writeAPIError(w, http.StatusBadRequest, "memory_failed", err.Error())
 		return
+	}
+	if items == nil {
+		items = []core.MemoryItem{}
 	}
 	writeAPIJSON(w, http.StatusOK, adminMemoryResponse{Items: items})
 }

--- a/internal/api/core_test.go
+++ b/internal/api/core_test.go
@@ -417,6 +417,95 @@ func TestHandleAdminRoomsAcceptsBuiltInAdminSecret(t *testing.T) {
 	}
 }
 
+func TestHandleAdminRoomsRegistersRoomWithAdminAuth(t *testing.T) {
+	api := NewServerWithCommandHandler(fakeCoreStore{
+		registerFn: func(_ context.Context, input core.RegisterRoomInput) (core.RegisterRoomResult, error) {
+			if input.Channel != "wecom" || input.ChannelRoomID != "room-1" || input.OutboundAlias != "测试群" || !input.AgentEnabled {
+				t.Fatalf("unexpected input: %+v", input)
+			}
+			return core.RegisterRoomResult{
+				Room: core.Room{
+					ID:              10,
+					TenantID:        core.DefaultTenantID,
+					Channel:         input.Channel,
+					ChannelRoomID:   input.ChannelRoomID,
+					ChannelRoomType: input.ChannelRoomType,
+					DisplayName:     input.DisplayName,
+					OutboundAlias:   input.OutboundAlias,
+				},
+				AgentSession: core.AgentSession{
+					ID:      100,
+					RoomID:  10,
+					Enabled: input.AgentEnabled,
+				},
+			}, nil
+		},
+	}, nil, "api-secret", "admin-secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/rooms", strings.NewReader(`{
+		"channel":"wecom",
+		"channel_room_id":"room-1",
+		"channel_room_type":"group",
+		"display_name":"测试群",
+		"outbound_alias":"测试群",
+		"agent_enabled":true
+	}`))
+	req.SetBasicAuth("admin", "admin-secret")
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload registerRoomResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Room.ID != 10 || payload.AgentSession.ID != 100 {
+		t.Fatalf("payload = %+v, want registered room", payload)
+	}
+}
+
+func TestHandleAdminAgentsListReturnsEmptyArray(t *testing.T) {
+	api := NewServerWithCommandHandler(fakeCoreStore{
+		agentsFn: func(context.Context) ([]core.Agent, error) {
+			return nil, nil
+		},
+	}, nil, "api-secret", "admin-secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/agents", nil)
+	req.SetBasicAuth("admin", "admin-secret")
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"agents":[]`) {
+		t.Fatalf("body = %s, want empty agents array", rec.Body.String())
+	}
+}
+
+func TestHandleAdminRoomMemoryReturnsEmptyArray(t *testing.T) {
+	api := NewServerWithCommandHandler(fakeCoreStore{
+		adminMemFn: func(context.Context, core.AdminMemoryListInput) ([]core.MemoryItem, error) {
+			return nil, nil
+		},
+	}, nil, "api-secret", "admin-secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/rooms/10/memory?status=active", nil)
+	req.SetBasicAuth("admin", "admin-secret")
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"items":[]`) {
+		t.Fatalf("body = %s, want empty memory items array", rec.Body.String())
+	}
+}
+
 func TestHandleAdminAgentsCreatesMutableAgent(t *testing.T) {
 	api := NewServerWithCommandHandler(fakeCoreStore{
 		createAgentFn: func(_ context.Context, input core.UpsertAgentInput) (core.Agent, error) {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -85,11 +86,31 @@ func withAdminUI(api http.Handler, distDir string) http.Handler {
 			return
 		}
 		if strings.HasPrefix(r.URL.Path, "/admin/") && !strings.HasPrefix(r.URL.Path, "/admin/api/") {
-			http.StripPrefix("/admin/", files).ServeHTTP(w, r)
+			relativePath := strings.TrimPrefix(r.URL.Path, "/admin/")
+			if shouldServeAdminFile(distDir, relativePath) {
+				http.StripPrefix("/admin/", files).ServeHTTP(w, r)
+				return
+			}
+			http.ServeFile(w, r, filepath.Join(distDir, "index.html"))
 			return
 		}
 		api.ServeHTTP(w, r)
 	})
+}
+
+func shouldServeAdminFile(distDir string, relativePath string) bool {
+	cleanPath := filepath.Clean(relativePath)
+	if cleanPath == "." || cleanPath == string(filepath.Separator) {
+		return true
+	}
+	if strings.HasPrefix(cleanPath, "..") {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(distDir, cleanPath))
+	if err != nil {
+		return strings.HasPrefix(cleanPath, "assets"+string(filepath.Separator))
+	}
+	return !info.IsDir()
 }
 
 func buildCommandHandler(cfg Config, coreStore *storage.CoreStore) *command.Handler {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWithAdminUIServesSPAForAdminDeepLinks(t *testing.T) {
+	distDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(distDir, "index.html"), []byte("<main>admin app</main>"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+
+	handler := withAdminUI(http.NotFoundHandler(), distDir)
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/10", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if !strings.Contains(rec.Body.String(), "admin app") {
+		t.Fatalf("body = %q, want index fallback", rec.Body.String())
+	}
+}
+
+func TestWithAdminUIKeepsMissingAssetsAsNotFound(t *testing.T) {
+	distDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(distDir, "index.html"), []byte("<main>admin app</main>"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+
+	handler := withAdminUI(http.NotFoundHandler(), distDir)
+	req := httptest.NewRequest(http.MethodGet, "/admin/assets/missing.js", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}

--- a/web/control/src/App.vue
+++ b/web/control/src/App.vue
@@ -5,6 +5,7 @@ import {
   Bot,
   Check,
   Database,
+  DoorOpen,
   KeyRound,
   Loader2,
   MessageSquarePlus,
@@ -124,6 +125,8 @@ const messageDeliveries = computed(() => {
 
 const canUseAPI = computed(() => credentials.value.clientId.length > 0 && credentials.value.clientSecret.length > 0)
 
+const canShowWorkspace = computed(() => selectedRoom.value !== null || activeTab.value === 'agents' || activeTab.value === 'settings')
+
 const formatDate = (value?: string) => {
   if (!value || value.startsWith('0001-')) return 'Never'
   return new Intl.DateTimeFormat(undefined, {
@@ -161,15 +164,27 @@ const syncSettingsFromSelectedRoom = () => {
     : ''
 }
 
+const resetRoomForm = () => {
+  settingsChannel.value = 'wecom'
+  settingsChannelRoomId.value = ''
+  settingsChannelRoomType.value = 'group'
+  settingsDisplayName.value = ''
+  settingsOutboundAlias.value = ''
+  settingsAgentEnabled.value = true
+  settingsTriggerPolicy.value = ''
+}
+
 const loadRooms = async () => {
   if (!canUseAPI.value) return
   roomLoading.value = true
   authError.value = ''
   try {
     const result = await api.listRooms(credentials.value)
-    rooms.value = result.rooms
-    if (!selectedRoomId.value && result.rooms.length) {
-      selectedRoomId.value = result.rooms[0].room.id
+    rooms.value = result.rooms ?? []
+    if (!rooms.value.some((summary) => summary.room.id === selectedRoomId.value)) {
+      selectedRoomId.value = rooms.value[0]?.room.id ?? null
+      timeline.value = null
+      memoryItems.value = []
     }
   } catch (error) {
     authError.value = error instanceof Error ? error.message : 'Failed to load rooms'
@@ -184,9 +199,9 @@ const loadAgents = async () => {
   actionError.value = ''
   try {
     const result = await api.listAgents(credentials.value)
-    agents.value = result.agents
-    if (!selectedAgentId.value && result.agents.length) {
-      selectedAgentId.value = result.agents[0].id
+    agents.value = result.agents ?? []
+    if (!agents.value.some((agent) => agent.id === selectedAgentId.value)) {
+      selectedAgentId.value = agents.value[0]?.id ?? null
     }
   } catch (error) {
     actionError.value = error instanceof Error ? error.message : 'Failed to load agents'
@@ -201,6 +216,9 @@ const loadTimeline = async () => {
   actionError.value = ''
   try {
     timeline.value = await api.getTimeline(credentials.value, selectedRoomId.value)
+    timeline.value.messages ??= []
+    timeline.value.deliveries ??= []
+    timeline.value.agent_sessions ??= []
   } catch (error) {
     actionError.value = error instanceof Error ? error.message : 'Failed to load timeline'
   } finally {
@@ -214,7 +232,7 @@ const loadMemory = async () => {
   actionError.value = ''
   try {
     const result = await api.listMemory(credentials.value, selectedRoomId.value, memoryStatus.value, memoryTypes.value)
-    memoryItems.value = result.items
+    memoryItems.value = result.items ?? []
   } catch (error) {
     actionError.value = error instanceof Error ? error.message : 'Failed to load memory'
   } finally {
@@ -226,6 +244,19 @@ const selectRoom = async (roomId: number) => {
   selectedRoomId.value = roomId
   activeTab.value = 'timeline'
   await loadTimeline()
+}
+
+const newRoom = () => {
+  selectedRoomId.value = null
+  timeline.value = null
+  memoryItems.value = []
+  activeTab.value = 'settings'
+  resetRoomForm()
+}
+
+const openAgents = async () => {
+  activeTab.value = 'agents'
+  await loadAgents()
 }
 
 const refreshCurrent = async () => {
@@ -279,7 +310,6 @@ const ackDelivery = async (deliveryId: number) => {
 }
 
 const saveRoomSettings = async () => {
-  if (!selectedRoom.value) return
   savingRoom.value = true
   actionError.value = ''
   try {
@@ -296,7 +326,8 @@ const saveRoomSettings = async () => {
       agent_enabled: settingsAgentEnabled.value,
       trigger_policy: triggerPolicy,
     }
-    await api.registerRoom(credentials.value, input)
+    const result = await api.registerRoom(credentials.value, input)
+    selectedRoomId.value = result.room.id
     await Promise.all([loadRooms(), loadTimeline()])
   } catch (error) {
     actionError.value = error instanceof Error ? error.message : 'Failed to save room settings'
@@ -423,12 +454,21 @@ onMounted(async () => {
         <div class="border-b border-line p-4">
           <div class="mb-3 flex items-center justify-between">
             <h2 class="text-sm font-700">Rooms</h2>
-            <span class="text-xs text-muted">{{ filteredRooms.length }} / {{ rooms.length }}</span>
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-muted">{{ filteredRooms.length }} / {{ rooms.length }}</span>
+              <button class="icon-button" title="New room" @click="newRoom">
+                <Plus class="h-4 w-4" />
+              </button>
+            </div>
           </div>
           <label class="flex items-center gap-2 rounded-6px border border-line bg-white px-3 py-2">
             <Search class="h-4 w-4 text-muted" />
             <input v-model="query" class="min-w-0 flex-1 bg-transparent text-sm outline-none" placeholder="Search rooms" />
           </label>
+          <button class="mt-3 w-full small-button justify-center" type="button" @click="openAgents">
+            <Bot class="h-3.5 w-3.5" />
+            Manage Agents
+          </button>
         </div>
 
         <div class="room-list h-[calc(100vh-150px)] overflow-y-auto">
@@ -460,18 +500,25 @@ onMounted(async () => {
       </aside>
 
       <section class="min-w-0 min-h-0">
-        <div v-if="selectedRoom" class="grid h-full grid-rows-[auto_auto_minmax(0,1fr)]">
+        <div v-if="canShowWorkspace" class="grid h-full grid-rows-[auto_auto_minmax(0,1fr)]">
           <div class="border-b border-line bg-surface px-5 py-4">
             <div class="flex items-start justify-between gap-4">
               <div class="min-w-0">
                 <h2 class="truncate text-xl font-750">
-                  {{ selectedRoom.room.display_name || selectedRoom.room.channel_room_id }}
+                  <template v-if="selectedRoom">
+                    {{ selectedRoom.room.display_name || selectedRoom.room.channel_room_id }}
+                  </template>
+                  <template v-else-if="activeTab === 'agents'">Agents</template>
+                  <template v-else>New Room</template>
                 </h2>
-                <p class="mt-1 text-sm text-muted">
+                <p v-if="selectedRoom" class="mt-1 text-sm text-muted">
                   #{{ selectedRoom.room.id }} · {{ selectedRoom.room.channel }} · {{ selectedRoom.room.channel_room_id }}
                 </p>
+                <p v-else class="mt-1 text-sm text-muted">
+                  Create and edit admin-managed TinyClaw records
+                </p>
               </div>
-              <div class="flex gap-2 text-xs">
+              <div v-if="selectedRoom" class="flex gap-2 text-xs">
                 <span class="status-pill">{{ selectedRoom.agent_session?.enabled ? 'Agent enabled' : 'Agent disabled' }}</span>
                 <span class="status-pill">{{ pendingDeliveries.length }} pending</span>
               </div>
@@ -480,10 +527,20 @@ onMounted(async () => {
 
           <div class="border-b border-line bg-surface px-5">
             <nav class="flex gap-1">
-              <button class="tab-button" :class="{ 'tab-button-active': activeTab === 'timeline' }" @click="activeTab = 'timeline'">
+              <button
+                class="tab-button"
+                :class="{ 'tab-button-active': activeTab === 'timeline' }"
+                :disabled="!selectedRoom"
+                @click="activeTab = 'timeline'"
+              >
                 Timeline
               </button>
-              <button class="tab-button" :class="{ 'tab-button-active': activeTab === 'memory' }" @click="activeTab = 'memory'">
+              <button
+                class="tab-button"
+                :class="{ 'tab-button-active': activeTab === 'memory' }"
+                :disabled="!selectedRoom"
+                @click="activeTab = 'memory'"
+              >
                 Memory
               </button>
               <button class="tab-button" :class="{ 'tab-button-active': activeTab === 'agents' }" @click="activeTab = 'agents'">
@@ -711,14 +768,17 @@ onMounted(async () => {
                   Trigger Policy JSON
                   <textarea v-model="settingsTriggerPolicy" class="field min-h-32 resize-y font-mono text-xs" />
                 </label>
-                <button class="primary-button justify-center" :disabled="savingRoom || !settingsOutboundAlias.trim()">
+                <button
+                  class="primary-button justify-center"
+                  :disabled="savingRoom || !settingsChannel.trim() || !settingsChannelRoomId.trim() || !settingsChannelRoomType.trim() || !settingsOutboundAlias.trim()"
+                >
                   <Loader2 v-if="savingRoom" class="h-4 w-4 animate-spin" />
                   <Check v-else class="h-4 w-4" />
-                  Save
+                  {{ selectedRoom ? 'Save Room' : 'Create Room' }}
                 </button>
               </form>
 
-              <div class="settings-grid">
+              <div v-if="selectedRoom" class="settings-grid">
                 <div class="settings-row">
                   <span>Room ID</span>
                   <code>{{ selectedRoom.room.id }}</code>
@@ -740,12 +800,28 @@ onMounted(async () => {
                   <code>{{ selectedRoom.agent_session?.caught_up_message_id || 0 }}</code>
                 </div>
               </div>
+              <div v-else class="empty-state">
+                <DoorOpen class="h-4 w-4" />
+                Fill the form to register a send-ready room.
+              </div>
             </section>
           </div>
         </div>
 
         <div v-else class="grid h-full place-items-center p-6">
-          <div class="empty-state">Connect with admin credentials to load rooms.</div>
+          <div class="grid justify-items-center gap-3">
+            <div class="empty-state px-8">Connect with admin credentials or create the first room.</div>
+            <div class="flex gap-2">
+              <button class="primary-button" type="button" :disabled="!canUseAPI" @click="newRoom">
+                <Plus class="h-4 w-4" />
+                New Room
+              </button>
+              <button class="small-button" type="button" :disabled="!canUseAPI" @click="openAgents">
+                <Bot class="h-3.5 w-3.5" />
+                Manage Agents
+              </button>
+            </div>
+          </div>
         </div>
       </section>
     </section>

--- a/web/control/src/api.ts
+++ b/web/control/src/api.ts
@@ -113,6 +113,11 @@ export type UpsertAgentInput = {
   enabled: boolean
 }
 
+export type RegisterRoomResult = {
+  room: Room
+  agent_session: AgentSession
+}
+
 const authHeader = (credentials: Credentials) => {
   const raw = `${credentials.clientId}:${credentials.clientSecret}`
   return `Basic ${btoa(unescape(encodeURIComponent(raw)))}`
@@ -172,7 +177,7 @@ export const api = {
   },
 
   registerRoom: (credentials: Credentials, input: RegisterRoomInput) =>
-    requestJSON('/api/rooms', credentials, {
+    requestJSON<RegisterRoomResult>('/admin/api/rooms', credentials, {
       method: 'POST',
       body: JSON.stringify(input),
     }),


### PR DESCRIPTION
## Purpose
Fix admin UI blank-page paths found while auditing https://claw.tiny.yun/admin/.

## Changes
- Serve the admin SPA index for non-asset /admin/* deep links.
- Add admin-authenticated room registration for the Room Settings form.
- Return empty arrays instead of null for admin agents and room memory.
- Defensively normalize nullable admin API arrays in the Vue control UI.
- Add empty-state access for New Room and Agents when no room is selected.

## Verification
- go test ./...
- pnpm run build
- git diff --check
- Browser-tested local mock responses for Timeline, Memory, Agents, Settings, Ack, Inject, Save Agent, Create Room, and null-array responses.